### PR TITLE
Refactor chat action handling and enhance enum functionality

### DIFF
--- a/balethon/client/chats/send_chat_action.py
+++ b/balethon/client/chats/send_chat_action.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 import balethon
+from balethon import enums
 
 
 class SendChatAction:
@@ -8,7 +9,7 @@ class SendChatAction:
     async def send_chat_action(
             self: "balethon.Client",
             chat_id: Union[int, str],
-            action: str = "typing"
+            action: "enums.ChatAction"
     ) -> bool:
         chat_id = await self.resolve_peer_id(chat_id)
         chat_id = str(chat_id)  # The sendChatAction method only works with a string chat_id

--- a/balethon/enums/chat_action.py
+++ b/balethon/enums/chat_action.py
@@ -5,3 +5,9 @@ from .name_enum import NameEnum
 
 class ChatAction(NameEnum):
     TYPING = auto()
+    UPLOAD_PHOTO = auto()
+    RECORD_VIDEO = auto()
+    UPLOAD_VIDEO = auto()
+    CHOOSE_STICKER = auto()
+    UPLOAD_VOICE = auto()
+    RECORD_VOICE = auto()

--- a/balethon/objects/object.py
+++ b/balethon/objects/object.py
@@ -134,6 +134,6 @@ def unwrap(wrapped_object):
         return wrapped_object.unwrap()
     
     if isinstance(wrapped_object, NameEnum):
-        return wrapped_object.value.lower()
+        return wrapped_object.value
 
     return wrapped_object

--- a/balethon/objects/object.py
+++ b/balethon/objects/object.py
@@ -2,6 +2,7 @@ from typing import get_type_hints, get_args, get_origin, Union, List, Optional
 from copy import copy
 from json import dumps
 
+from ..enums import NameEnum
 import balethon
 
 
@@ -131,5 +132,8 @@ def unwrap(wrapped_object):
 
     if isinstance(wrapped_object, Object):
         return wrapped_object.unwrap()
+    
+    if isinstance(wrapped_object, NameEnum):
+        return wrapped_object.value.lower()
 
     return wrapped_object


### PR DESCRIPTION
Refactor the `send_chat_action` method to utilize the `ChatAction` enum, improving clarity and maintainability. Expand the `ChatAction` enum with additional actions to provide more options. Fix the unwrap function to correctly return `NameEnum` values without unnecessary conversions.